### PR TITLE
Rename/Fix press command for cypress 14.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@walmyr-filho%2Fcy-press.svg)](https://badge.fury.io/js/@walmyr-filho%2Fcy-press)
 
-A silly Cypress `.press()` command that simulates pressing a keyboard key.
+A silly Cypress `.customPress()` command that simulates pressing a keyboard key.
 
 ## Installation
 
@@ -20,7 +20,7 @@ import '@walmyr-filho/cy-press'
 // require('@walmyr-filho/cy-press')
 ```
 
-Then, inside the test file, chain the `.press()` command to a typeable field (for example), and pass to it a [valid key](#available-keys) (e.g., `'enter'` or `'backspace'`)
+Then, inside the test file, chain the `.customPress()` command to a typeable field (for example), and pass to it a [valid key](#available-keys) (e.g., `'enter'` or `'backspace'`)
 
 ✅ **Correct usage**
 
@@ -32,7 +32,7 @@ it('types and presses enter', () => {
 
   cy.get('input[type="text"]')
     .type('cypress.io')
-    .press('enter')
+    .customPress('enter')
 
   // Assertion here
 })
@@ -46,7 +46,7 @@ it('types and presses enter', () => {
 it('tries to press without a subject element', () => {
   cy.visit('https://example.com/searchForm')
 
-  cy.press('enter') // This won't work and will result in an error
+  cy.customPress('enter') // This won't work and will result in an error
 })
 ```
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,8 +7,8 @@ declare namespace Cypress {
      *
      * @param key string - The key you want to press. Available keys are: selectAll, moveToStart, moveToEnd, del, backspace, esc, enter, rightArrow, leftArrow, upArrow, downArrow, home, end, insert, pageUp, pageDown, {, alt, option, ctrl, control, meta, command, cmd, shift, ctrl+a, CTRL+A, cmd+a, CMD+A
      *
-     * @example cy.get('input[type="text"]').type('something').press('enter')
-     * @example cy.get('input[type="text"]').type('yoo').press('backspace').press('enter')
+     * @example cy.get('input[type="text"]').type('something').customPress('enter')
+     * @example cy.get('input[type="text"]').type('yoo').press('backspace').customPress('enter')
      */
     press(key: string): Cypress.Chainable
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-Cypress.Commands.add('press', { prevSubject: true }, (subject, key) => {
+Cypress.Commands.add('customPress', { prevSubject: true }, (subject, key) => {
   if (!key) throw new Error('You need to provide a key (e.g, .press("enter"))')
 
   const log = Cypress.log({
     autoEnd: false,
-    name: 'press',
-    displayName: 'press',
+    name: 'customPress',
+    displayName: 'customPress',
     message: `pressing ${key}`,
     consoleProps: () => {
       return { Key: key }


### PR DESCRIPTION
This pull request includes changes to rename the `.press()` command to `.customPress()` in the Cypress plugin and its documentation. The primary goal is to update the command name for it to coexist with the native `.press()` command that was introduced in Cypress version 14.3.0.

This fixes issue https://github.com/wlsf82/cy-press/issues/4

Renaming command:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Updated all instances of `.press()` to `.customPress()` to reflect the new command name. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R49)
* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L1-R7): Renamed the Cypress command from `press` to `customPress`, and updated the related log messages accordingly.