### PR TITLE
Add deprecation warning for 'press' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![npm version](https://badge.fury.io/js/@walmyr-filho%2Fcy-press.svg)](https://badge.fury.io/js/@walmyr-filho%2Fcy-press)
 
+> ⚠️ **DEPRECATION WARNING**: The `press` command will be deprecated in a future release. Please consider using Cypress's native `.type()` command with key modifiers instead (e.g., `.type('{enter}')` instead of `.press('enter')`).
+
 A silly Cypress `.press()` command that simulates pressing a keyboard key.
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walmyr-filho/cy-press",
   "version": "1.0.5",
-  "description": "A silly Cypress `.press()` command that simulates pressing a keyboard key.",
+  "description": "A silly Cypress `.press()` command that simulates pressing a keyboard key. ⚠️ DEPRECATED: Will be deprecated in a future release.",
   "main": "src",
   "files": [
     "src"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,10 @@ declare namespace Cypress {
   interface Chainable {
     /**
      * **Simulates pressing a keyboard key.**
+     * 
+     * @deprecated ⚠️ The 'press' command will be deprecated in a future release. 
+     * Consider using Cypress's native .type() command with key modifiers instead 
+     * (e.g., .type('{enter}') instead of .press('enter')).
      *
      * @param key string - The key you want to press. Available keys are: selectAll, moveToStart, moveToEnd, del, backspace, esc, enter, rightArrow, leftArrow, upArrow, downArrow, home, end, insert, pageUp, pageDown, {, alt, option, ctrl, control, meta, command, cmd, shift, ctrl+a, CTRL+A, cmd+a, CMD+A
      *

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,14 @@
 Cypress.Commands.add('press', { prevSubject: true }, (subject, key) => {
   if (!key) throw new Error('You need to provide a key (e.g, .press("enter"))')
 
+  // Deprecation warning
+  Cypress.log({
+    name: 'warn',
+    displayName: 'warn',
+    message: '⚠️ DEPRECATION WARNING: The "press" command will be deprecated in a future release. Consider using Cypress\'s native .type() command with key modifiers instead.',
+    consoleProps: () => ({ Warning: 'The "press" command is deprecated' })
+  })
+
   const log = Cypress.log({
     autoEnd: false,
     name: 'press',


### PR DESCRIPTION
- Add prominent warning in README.md
- Add runtime warning in index.js
- Add @deprecated JSDoc tag in index.d.ts
- Update package.json description with deprecation notice

The 'press' command will be deprecated in a future release. Users should migrate to using Cypress's native .type() command with key modifiers instead.